### PR TITLE
Start draft specification as XML schema file

### DIFF
--- a/dta.xsd
+++ b/dta.xsd
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
+    vc:minVersion="1.1">
+    <xs:element name="tournament">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="round">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="debate">
+                                <xs:complexType>
+                                    <xs:choice>
+                                        <xs:element name="speech">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element name="ballot"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="reply" type="xs:boolean"/>
+                                                <xs:attribute name="enhancements">
+                                                  <xs:simpleType>
+                                                  <xs:list itemType="xs:string"/>
+                                                  </xs:simpleType>
+                                                </xs:attribute>
+                                                <xs:attribute name="speaker"/>
+                                            </xs:complexType>
+                                            <xs:keyref name="speech_speaker" refer="speaker_name">
+                                                <xs:selector xpath="speech"/>
+                                                <xs:field xpath="speaker"/>
+                                            </xs:keyref>
+                                        </xs:element>
+                                        <xs:element name="ballot"/>
+                                    </xs:choice>
+                                    <xs:attribute name="motion"/>
+                                    <xs:attribute name="venue"/>
+                                </xs:complexType>
+                                <xs:keyref name="debate_motion" refer="motion_ref">
+                                    <xs:selector xpath="debate"/>
+                                    <xs:field xpath="motion"/>
+                                </xs:keyref>
+                                <xs:keyref name="debate_venue" refer="venue_ref">
+                                    <xs:selector xpath="debate"/>
+                                    <xs:field xpath="venue"/>
+                                </xs:keyref>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="elimination" type="xs:boolean"/>
+                        <xs:attribute name="name" type="xs:string"/>
+                        <xs:attribute name="abbreviation" type="xs:string"/>
+                        <xs:attribute name="motion"/>
+                    </xs:complexType>
+                    <xs:keyref name="round_motions" refer="motion_ref">
+                        <xs:selector xpath="round"/>
+                        <xs:field xpath="motion"/>
+                    </xs:keyref>
+                </xs:element>
+                <xs:element name="participants">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="team">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="speaker">
+                                            <xs:complexType>
+                                                <xs:attribute name="institutions"/>
+                                                <xs:attribute name="email"/>
+                                                <xs:attribute name="name"/>
+                                            </xs:complexType>
+                                            <xs:key name="speaker_name">
+                                                <xs:selector xpath="speaker"/>
+                                                <xs:field xpath="named"/>
+                                            </xs:key>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="name"/>
+                                    <xs:attribute name="reference" type="xs:string"/>
+                                    <xs:attribute name="institution"/>
+                                    <xs:attribute name="code"/>
+                                </xs:complexType>
+                                <xs:key name="team_ref">
+                                    <xs:selector xpath="team"/>
+                                    <xs:field xpath="reference"/>
+                                </xs:key>
+                            </xs:element>
+                            <xs:element name="adjudicator">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="feedback">
+                                            <xs:complexType>
+                                                <xs:attribute name="source-team"/>
+                                                <xs:attribute name="source-adjudicator"/>
+                                            </xs:complexType>
+                                            <xs:keyref name="feedback_source-team" refer="team_ref">
+                                                <xs:selector xpath="feedback"/>
+                                                <xs:field xpath="source-team"/>
+                                            </xs:keyref>
+                                            <xs:keyref name="feedback_source-adj" refer="adj_name">
+                                                <xs:selector xpath="feedback"/>
+                                                <xs:field xpath="source-adjudicator"/>
+                                            </xs:keyref>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="institutions"/>
+                                    <xs:attribute name="current-institution"/>
+                                    <xs:attribute name="name"/>
+                                    <xs:attribute name="score" type="xs:decimal"/>
+                                    <xs:attribute name="core" type="xs:boolean"/>
+                                    <xs:attribute name="independant" type="xs:boolean"/>
+                                </xs:complexType>
+                                <xs:key name="adj_name">
+                                    <xs:selector xpath="adjudicator"/>
+                                    <xs:field xpath="name"/>
+                                </xs:key>
+                                <xs:keyref name="adjudicator_current-institution"
+                                    refer="institution_ref">
+                                    <xs:selector xpath="adjudicator"/>
+                                    <xs:field xpath="current-institution"/>
+                                </xs:keyref>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:all>
+            <xs:attribute name="name"/>
+            <xs:attribute name="format"/>
+            <xs:attribute name="start-date"/>
+            <xs:attribute name="end-date"/>
+            <xs:attribute name="host"/>
+        </xs:complexType>
+        <xs:keyref name="tournament_host" refer="institution_ref">
+            <xs:selector xpath="tournament"/>
+            <xs:field xpath="host"/>
+        </xs:keyref>
+    </xs:element>
+    <xs:element name="motion">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="info-slide"/>
+                <xs:element name="resolution"/>
+            </xs:sequence>
+            <xs:attribute name="reference"/>
+        </xs:complexType>
+        <xs:key name="motion_ref">
+            <xs:selector xpath="motion"/>
+            <xs:field xpath="reference"/>
+        </xs:key>
+    </xs:element>
+    <xs:element name="institution">
+        <xs:complexType>
+            <xs:attribute name="reference"/>
+            <xs:attribute name="name"/>
+        </xs:complexType>
+        <xs:key name="institution_ref">
+            <xs:selector xpath="institution"/>
+            <xs:field xpath="reference"/>
+        </xs:key>
+    </xs:element>
+    <xs:element name="venues">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="venue-category">
+                    <xs:complexType>
+                        <xs:attribute name="reference"/>
+                    </xs:complexType>
+                    <xs:key name="venue-category_ref">
+                        <xs:selector xpath="venue-category"/>
+                        <xs:field xpath="reference"/>
+                    </xs:key>
+                </xs:element>
+                <xs:element name="venue">
+                    <xs:complexType>
+                        <xs:attribute name="reference"/>
+                        <xs:attribute name="categories" use="required"/>
+                    </xs:complexType>
+                    <xs:key name="venue_ref">
+                        <xs:selector xpath="venue"/>
+                        <xs:field xpath="reference"/>
+                    </xs:key>
+                    <xs:keyref name="venue_categories" refer="venue-category_ref">
+                        <xs:selector xpath="venue"/>
+                        <xs:field xpath="categories"/>
+                    </xs:keyref>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/dta.xsd
+++ b/dta.xsd
@@ -297,6 +297,9 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 						<xs:documentation>A question posed to participant(s) of each debate on an adjudicator. The text of the question should be its content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="choice"/>
+						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID"/>
 						<xs:attribute name="name" type="xs:string"/>
 						<xs:attribute name="type" type="xs:string">
@@ -306,11 +309,6 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 						</xs:attribute>
 						<xs:attribute name="from-teams" type="xs:boolean"/>
 						<xs:attribute name="from-adjudicators" type="xs:boolean"/>
-						<xs:attribute name="choices" type="xs:string" use="optional">
-							<xs:annotation>
-								<xs:documentation>Separate using pipes (&quot;|&quot;). Only use if type is of a choice.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
 					</xs:complexType>
 					<xs:key name="question_id">
 						<xs:selector xpath="question"/>

--- a/dta.xsd
+++ b/dta.xsd
@@ -60,10 +60,10 @@
 									<xs:attribute name="id" type="xs:ID"/>
 									<xs:attribute name="chair" type="xs:IDREF" use="optional"/>
 									<xs:attribute name="venue" type="xs:IDREF" use="optional"/>
-									<xs:attribute name="motion" type="xs:IDREF"/>
+									<xs:attribute name="motion" type="xs:IDREF" use="optional"/>
 									<xs:attribute name="adjudicators" type="xs:IDREFS">
 										<xs:annotation>
-											<xs:documentation xml:lang="en">The first adjudicator listed will be considered the chair if no chair explicitly specified.</xs:documentation>
+											<xs:documentation xml:lang="en">The first adjudicator listed will be considered the chair if no chair explicitly specified. Also include adjudicators who did not participate in scoring (trainees).</xs:documentation>
 										</xs:annotation>
 									</xs:attribute>
 								</xs:complexType>
@@ -150,6 +150,12 @@
 									<xs:attribute name="code" type="xs:string"/>
 									<xs:attribute name="name" type="xs:string"/>
 									<xs:attribute name="break-eligibilities" type="xs:IDREFS"/>
+									<xs:attribute name="division" type="xs:IDREF" use="optional"/>
+									<xs:attribute name="swing" type="xs:boolean" default="false">
+										<xs:annotation>
+											<xs:documentation xml:lang="en">Swing teams are ineligible for breaks. They are normally formed when there are not enough eligible teams.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
 								</xs:complexType>
 								<xs:key name="team_id">
 									<xs:selector xpath="team"/>
@@ -158,6 +164,10 @@
 								<xs:keyref name="team_break_categories" refer="break_category_id">
 									<xs:selector xpath="team"/>
 									<xs:field xpath="@break-eligibilities"/>
+								</xs:keyref>
+								<xs:keyref name="team_division" refer="division_id">
+									<xs:selector xpath="team"/>
+									<xs:field xpath="@division"/>
 								</xs:keyref>
 							</xs:element>
 							<xs:element name="adjudicator" minOccurs="1" maxOccurs="unbounded">
@@ -278,6 +288,7 @@
 									</xs:annotation>
 								</xs:attribute>
 								<xs:attribute name="score" type="xs:float" use="optional"/>
+								<xs:attribute name="division" type="xs:IDREF" use="optional"/>
 							</xs:extension>
 						</xs:simpleContent>
 					</xs:complexType>
@@ -285,6 +296,10 @@
 						<xs:selector xpath="venue"/>
 						<xs:field xpath="@id"/>
 					</xs:key>
+					<xs:keyref name="venue_division" refer="division_id">
+						<xs:selector xpath="venue"/>
+						<xs:field xpath="@division"/>
+					</xs:keyref>
 				</xs:element>
 				<xs:element name="question" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
@@ -352,10 +367,30 @@
 						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
+				<xs:element name="division" minOccurs="0" maxOccurs="5">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">Divisions are groupings of teams that compete amongst themselves, but within the same tournament as teams in different divisions. Its name should be its content.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="id" type="xs:ID"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+					<xs:key name="division_id">
+						<xs:selector xpath="division"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
 			</xs:sequence>
 			<xs:attribute name="name" type="xs:string"/>
 			<xs:attribute name="short" type="xs:string" use="optional"/>
-			<xs:attribute name="host" type="xs:string" use="optional"/>
+			<xs:attribute name="host" type="xs:string" use="optional">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The organizing institution(s). Nominally a string-type, could contain IDREFS towards institutions.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
 			<xs:attribute name="style" use="optional">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">An enumeration of many standardized tournament formats: apda for American Parliamentary Debate Association, asians for Asian Parliamentary Debate, aus-easters for Australian Easters, australs for Australs, bp for British Parliamentary, cndc for Canadian National Debating Championships, cp for Canadian Parliamentary, ffd for Fédération Francophone de Débat, joynt for Joynt Scroll, ld for Lincoln–Douglas, npda for National Parliamentary Debate Association, nz-easters for New Zealand Easters, opd for Offene parlamentarische Debatte, paris-v for Paris V, uadc for United Asians Debating Championships, wadl for Western Australian Debating League, and wsdc for World Schools Debating Championships.</xs:documentation>

--- a/dta.xsd
+++ b/dta.xsd
@@ -3,39 +3,39 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<xs:element name="tournament">
 		<xs:annotation>
-			<xs:documentation>Tournaments are the core of the data collected as part of debates.</xs:documentation>
+			<xs:documentation xml:lang="en">Tournaments are the core of the data collected as part of debates.</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="round" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
+						<xs:documentation xml:lang="en">A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="debate" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result. Byes are represented by having only one side to a debate.</xs:documentation>
+									<xs:documentation xml:lang="en">Debates are collections of speeches between competitors which are compared to form a score/result. Byes are represented by having only one side to a debate.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>
 									<xs:sequence>
 										<xs:element name="side" minOccurs="2" maxOccurs="4">
 											<xs:annotation>
-												<xs:documentation>Opposing speeches are often grouped as sides to a debate, with each team representing a position.</xs:documentation>
+												<xs:documentation xml:lang="en">Opposing speeches are often grouped as sides to a debate, with each team representing a position.</xs:documentation>
 											</xs:annotation>
 											<xs:complexType>
 												<xs:sequence>
 													<xs:element ref="ballot" minOccurs="1" maxOccurs="unbounded"/>
 													<xs:element name="speech" minOccurs="0" maxOccurs="10">
 														<xs:annotation>
-															<xs:documentation>Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred. Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
+															<xs:documentation xml:lang="en">Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred. Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
 														</xs:annotation>
 														<xs:complexType>
 															<xs:sequence>
 																<xs:element ref="ballot" minOccurs="0" maxOccurs="unbounded"/>
 															</xs:sequence>
 															<xs:attribute name="speaker" type="xs:IDREF"/>
-															<xs:attribute name="reply" type="xs:boolean"/>
+															<xs:attribute name="reply" type="xs:boolean" default="false"/>
 														</xs:complexType>
 														<xs:keyref name="speech_speaker" refer="speaker_id">
 															<xs:selector xpath="speech"/>
@@ -45,10 +45,15 @@
 												</xs:sequence>
 												<xs:attribute name="team" type="xs:IDREF"/>
 												<xs:attribute name="forfeit" type="xs:boolean" use="optional" default="false"/>
+												<xs:attribute name="motion-veto" type="xs:IDREF" use="optional"/>
 											</xs:complexType>
 											<xs:keyref name="side_team" refer="team_id">
 												<xs:selector xpath="side"/>
 												<xs:field xpath="@team"/>
+											</xs:keyref>
+											<xs:keyref name="side_veto" refer="motion_id">
+												<xs:selector xpath="side"/>
+												<xs:field xpath="@motion-veto"/>
 											</xs:keyref>
 										</xs:element>
 									</xs:sequence>
@@ -56,7 +61,11 @@
 									<xs:attribute name="chair" type="xs:IDREF" use="optional"/>
 									<xs:attribute name="venue" type="xs:IDREF" use="optional"/>
 									<xs:attribute name="motion" type="xs:IDREF"/>
-									<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+									<xs:attribute name="adjudicators" type="xs:IDREFS">
+										<xs:annotation>
+											<xs:documentation xml:lang="en">The first adjudicator listed will be considered the chair if no chair explicitly specified.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
 								</xs:complexType>
 								<xs:key name="debate_id">
 									<xs:selector xpath="debate"/>
@@ -79,6 +88,15 @@
 									<xs:field xpath="@adjudicators"/>
 								</xs:keyref>
 							</xs:element>
+							<xs:element name="bye" minOccurs="0" type="xs:IDREF" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation xml:lang="en">A bye is where a debate could not be held due to a lack of teams as not all of the assigned teams to the debate are present. The ID of the present team should be the content.</xs:documentation>
+								</xs:annotation>
+								<xs:keyref name="bye_team" refer="team_id">
+									<xs:selector xpath="bye"/>
+									<xs:field xpath="."/>
+								</xs:keyref>
+							</xs:element>
 						</xs:sequence>
 						<xs:attribute name="name" type="xs:string"/>
 						<xs:attribute default="false" name="elimination" type="xs:boolean"/>
@@ -93,19 +111,19 @@
 				</xs:element>
 				<xs:element name="participants">
 					<xs:annotation>
-						<xs:documentation>Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
+						<xs:documentation xml:lang="en">Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
 							<xs:element name="team" minOccurs="2" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
+									<xs:documentation xml:lang="en">Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>
 									<xs:sequence>
 										<xs:element name="speaker" minOccurs="0" maxOccurs="10">
 											<xs:annotation>
-												<xs:documentation>Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type. Their name should be the content of the element.</xs:documentation>
+												<xs:documentation xml:lang="en">Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type. Their name should be the content of the element.</xs:documentation>
 											</xs:annotation>
 											<xs:complexType>
 												<xs:complexContent>
@@ -144,7 +162,7 @@
 							</xs:element>
 							<xs:element name="adjudicator" minOccurs="1" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
+									<xs:documentation xml:lang="en">While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType mixed="true">
 									<xs:complexContent>
@@ -155,7 +173,7 @@
 														<xs:sequence>
 															<xs:element name="answer" minOccurs="0" maxOccurs="unbounded">
 																<xs:annotation>
-																	<xs:documentation>The content should be the answer given.</xs:documentation>
+																	<xs:documentation xml:lang="en">The content should be the answer given.</xs:documentation>
 																</xs:annotation>
 																<xs:complexType>
 																	<xs:simpleContent>
@@ -209,7 +227,7 @@
 				</xs:element>
 				<xs:element name="institution" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution. Its name should be the content.</xs:documentation>
+						<xs:documentation xml:lang="en">Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution. Its name should be the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:simpleContent>
@@ -226,19 +244,20 @@
 				</xs:element>
 				<xs:element name="motion" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them. The resolution should be the non-element content of the tag.</xs:documentation>
+						<xs:documentation xml:lang="en">Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them. The resolution should be the non-element content of the tag.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType mixed="true">
 						<xs:sequence>
 							<xs:element name="info-slide" type="xs:string" minOccurs="0" maxOccurs="1"/>
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID" use="required"/>
-						<xs:attribute name="reference"/>
+						<xs:attribute name="reference" type="xs:string"/>
 						<xs:attribute name="language" type="xs:string" use="optional">
 							<xs:annotation>
-								<xs:documentation>The language(s) of the motion/the debates using the motion. Use ISO 639 codes, separated by whitespace.</xs:documentation>
+								<xs:documentation xml:lang="en">The language(s) of the motion/the debates using the motion. Use ISO 639 codes, separated by whitespace.</xs:documentation>
 							</xs:annotation>
 						</xs:attribute>
+						<xs:attribute name="contentious" type="xs:boolean" default="false" use="optional"/>
 					</xs:complexType>
 					<xs:key name="motion_id">
 						<xs:selector xpath="motion"/>
@@ -247,7 +266,7 @@
 				</xs:element>
 				<xs:element name="venue" minOccurs="1" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced. Its name, excluding category suffixes, should be the content.</xs:documentation>
+						<xs:documentation xml:lang="en">Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced. Its name, excluding category suffixes, should be the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:simpleContent>
@@ -255,7 +274,7 @@
 								<xs:attribute name="id" type="xs:ID" use="required"/>
 								<xs:attribute name="categories" use="optional">
 									<xs:annotation>
-										<xs:documentation>Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
+										<xs:documentation xml:lang="en">Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
 									</xs:annotation>
 								</xs:attribute>
 								<xs:attribute name="score" type="xs:float" use="optional"/>
@@ -269,7 +288,7 @@
 				</xs:element>
 				<xs:element name="question" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>A question posed to participant(s) of each debate on an adjudicator. The text of the question should be its content.</xs:documentation>
+						<xs:documentation xml:lang="en">A question posed to participant(s) of each debate on an adjudicator. The text of the question should be its content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType mixed="true">
 						<xs:sequence>
@@ -277,10 +296,23 @@
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID"/>
 						<xs:attribute name="name" type="xs:string"/>
-						<xs:attribute name="type" type="xs:string">
+						<xs:attribute name="type">
 							<xs:annotation>
-								<xs:documentation>Type can be one of the following: bc for checkbox, bs for yes/no (dropdown), i for integer (textbox), is for integer scale, f for float, t for text, tl for long text, ss for select one, ms for select multiple</xs:documentation>
+								<xs:documentation xml:lang="en">Type can be one of the following: bc for checkbox, bs for yes/no (dropdown), i for integer (textbox), is for integer scale, f for float, t for text, tl for long text, ss for select one, ms for select multiple</xs:documentation>
 							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:enumeration value="bc"/>
+									<xs:enumeration value="bs"/>
+									<xs:enumeration value="i"/>
+									<xs:enumeration value="is"/>
+									<xs:enumeration value="f"/>
+									<xs:enumeration value="t"/>
+									<xs:enumeration value="tl"/>
+									<xs:enumeration value="ss"/>
+									<xs:enumeration value="ms"/>
+								</xs:restriction>
+							</xs:simpleType>
 						</xs:attribute>
 						<xs:attribute name="from-teams" type="xs:boolean"/>
 						<xs:attribute name="from-adjudicators" type="xs:boolean"/>
@@ -292,7 +324,7 @@
 				</xs:element>
 				<xs:element name="break-category" minOccurs="0" maxOccurs="10">
 					<xs:annotation>
-						<xs:documentation>A break category. Its name should be the content.</xs:documentation>
+						<xs:documentation xml:lang="en">A break category. Its name should be the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:simpleContent>
@@ -324,24 +356,57 @@
 			<xs:attribute name="name" type="xs:string"/>
 			<xs:attribute name="short" type="xs:string" use="optional"/>
 			<xs:attribute name="host" type="xs:string" use="optional"/>
-			<xs:attribute name="style" type="xs:string" use="optional"/>
-			<xs:attribute name="language" type="xs:string" use="optional"/>
+			<xs:attribute name="style" use="optional">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">An enumeration of many standardized tournament formats: apda for American Parliamentary Debate Association, asians for Asian Parliamentary Debate, aus-easters for Australian Easters, australs for Australs, bp for British Parliamentary, cndc for Canadian National Debating Championships, cp for Canadian Parliamentary, ffd for Fédération Francophone de Débat, joynt for Joynt Scroll, ld for Lincoln–Douglas, npda for National Parliamentary Debate Association, nz-easters for New Zealand Easters, opd for Offene parlamentarische Debatte, paris-v for Paris V, uadc for United Asians Debating Championships, wadl for Western Australian Debating League, and wsdc for World Schools Debating Championships.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:enumeration value="apda"/>
+						<xs:enumeration value="asians"/>
+						<xs:enumeration value="aus-easters"/>
+						<xs:enumeration value="australs"/>
+						<xs:enumeration value="bp"/>
+						<xs:enumeration value="cndc"/>
+						<xs:enumeration value="cp"/>
+						<xs:enumeration value="ffd"/>
+						<xs:enumeration value="joynt"/>
+						<xs:enumeration value="ld"/>
+						<xs:enumeration value="npda"/>
+						<xs:enumeration value="nz-easters"/>
+						<xs:enumeration value="opd"/>
+						<xs:enumeration value="paris-v"/>
+						<xs:enumeration value="uadc"/>
+						<xs:enumeration value="wadl"/>
+						<xs:enumeration value="wsdc"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="language" type="xs:string" use="optional">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">Please use ISO 639 codes.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
 			<xs:attribute name="start-date" type="xs:date" use="optional"/>
 			<xs:attribute name="end-date" type="xs:date" use="optional"/>
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="ballot">
 		<xs:annotation>
-			<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score, or whether the team advanced (true/false), should be its content. Win or lose should be determined by comparing the rank or the score of all sides of the debate. Please note that it is not the collection of scores by the same adjudicator. The score should be its content, using criteria subelements if applicable.</xs:documentation>
+			<xs:documentation xml:lang="en">A ballot is an atomic score/result given by one or more adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score, or whether the team advanced (true/false), should be its content. Win or lose should be determined by comparing the rank or the score of all sides of the debate. Please note that it is not the collection of scores by the same adjudicator. The score should be its content, using criteria subelements if applicable.</xs:documentation>
 		</xs:annotation>
 		<xs:complexType mixed="true">
 			<xs:sequence>
 				<xs:element name="score" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
-						<xs:documentation>One of the scores given for the speech in relation to a marking rubric. The score is the content.</xs:documentation>
+						<xs:documentation xml:lang="en">One of the scores given for the speech in relation to a marking rubric. The score is the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
-						<xs:attribute name="criterion" type="xs:string"/>
+						<xs:simpleContent>
+							<xs:extension base="xs:decimal">
+								<xs:attribute name="criterion" type="xs:string"/>
+							</xs:extension>
+						</xs:simpleContent>
 					</xs:complexType>
 				</xs:element>
 			</xs:sequence>
@@ -358,6 +423,9 @@
 	<xs:complexType name="person" mixed="true">
 		<xs:attribute name="id" type="xs:ID"/>
 		<xs:attribute name="gender" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">m for male, f for female, and o for other.</xs:documentation>
+			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:string">
 					<xs:enumeration value="m"/>

--- a/dta.xsd
+++ b/dta.xsd
@@ -7,70 +7,32 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="round">
+				<xs:element name="round" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="debate">
+							<xs:element name="debate" maxOccurs="unbounded">
 								<xs:annotation>
 									<xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result. Byes are represented by having only one side to a debate.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>
 									<xs:sequence>
-										<xs:element name="side">
+										<xs:element name="side" minOccurs="2" maxOccurs="4">
 											<xs:annotation>
 												<xs:documentation>Opposing speeches are often grouped as sides to a debate, with each team representing a position.</xs:documentation>
 											</xs:annotation>
 											<xs:complexType>
 												<xs:sequence>
-													<xs:element name="ballot">
+													<xs:element ref="ballot" minOccurs="1" maxOccurs="unbounded"/>
+													<xs:element name="speech" minOccurs="0" maxOccurs="10">
 														<xs:annotation>
-															<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score, or whether the team advanced (true/false), should be its content. Win or lose should be determined by comparing the rank or the score of all sides of the debate.</xs:documentation>
-														</xs:annotation>
-														<xs:complexType>
-															<xs:attribute name="adjudicators" type="xs:IDREFS"/>
-															<xs:attribute default="false" name="minority" type="xs:boolean"/>
-															<xs:attribute name="rank" type="xs:integer" use="optional"/>
-															<xs:attribute default="false" name="ignored" type="xs:boolean" use="optional"/>
-														</xs:complexType>
-														<xs:keyref name="team_ballot_adjudicators" refer="adjudicator_id">
-															<xs:selector xpath="side/ballot"/>
-															<xs:field xpath="@adjudicators"/>
-														</xs:keyref>
-													</xs:element>
-													<xs:element name="speech">
-														<xs:annotation>
-															<xs:documentation>Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred.
-
-Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
+															<xs:documentation>Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred. Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
 														</xs:annotation>
 														<xs:complexType>
 															<xs:sequence>
-																<xs:element name="ballot">
-																	<xs:annotation>
-																		<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score should be its content, with criteria if applicable.</xs:documentation>
-																	</xs:annotation>
-																	<xs:complexType>
-																		<xs:sequence>
-																			<xs:element name="score">
-																				<xs:annotation>
-																					<xs:documentation>One of the scores given for the speech in relation to a marking rubric. The score is the content.</xs:documentation>
-																				</xs:annotation>
-																				<xs:complexType>
-																					<xs:attribute name="criterion" type="xs:string"/>
-																				</xs:complexType>
-																			</xs:element>
-																		</xs:sequence>
-																		<xs:attribute name="adjudicators" type="xs:IDREFS"/>
-																		<xs:attribute name="rank" type="xs:integer" use="optional"/>
-																	</xs:complexType>
-																	<xs:keyref name="speech_ballot_adjudicators" refer="adjudicator_id">
-																		<xs:selector xpath="speech/ballot"/>
-																		<xs:field xpath="@adjudicators"/>
-																	</xs:keyref>
-																</xs:element>
+																<xs:element ref="ballot" minOccurs="0" maxOccurs="unbounded"/>
 															</xs:sequence>
 															<xs:attribute name="speaker" type="xs:IDREF"/>
 															<xs:attribute name="reply" type="xs:boolean"/>
@@ -135,21 +97,22 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="team">
+							<xs:element name="team" minOccurs="2" maxOccurs="unbounded">
 								<xs:annotation>
 									<xs:documentation>Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>
 									<xs:sequence>
-										<xs:element name="speaker">
+										<xs:element name="speaker" minOccurs="0" maxOccurs="10">
 											<xs:annotation>
 												<xs:documentation>Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type. Their name should be the content of the element.</xs:documentation>
 											</xs:annotation>
 											<xs:complexType>
-												<xs:attribute name="id" type="xs:ID"/>
-												<xs:attribute name="gender" type="xs:string" use="optional"/>
-												<xs:attribute name="institutions" type="xs:IDREFS"/>
-												<xs:attribute name="categories" type="xs:IDREFS"/>
+												<xs:complexContent>
+													<xs:extension base="person">
+														<xs:attribute name="categories" type="xs:IDREFS"/>
+													</xs:extension>
+												</xs:complexContent>
 											</xs:complexType>
 											<xs:key name="speaker_id">
 												<xs:selector xpath="speaker"/>
@@ -157,7 +120,7 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 											</xs:key>
 											<xs:keyref name="speaker_institution" refer="institution_id">
 												<xs:selector xpath="speaker"/>
-												<xs:field xpath="@institution"/>
+												<xs:field xpath="@institutions"/>
 											</xs:keyref>
 											<xs:keyref name="speaker_categories" refer="speaker_category_id">
 												<xs:selector xpath="speaker"/>
@@ -179,54 +142,58 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 									<xs:field xpath="@break-eligibilities"/>
 								</xs:keyref>
 							</xs:element>
-							<xs:element name="adjudicator">
+							<xs:element name="adjudicator" minOccurs="1" maxOccurs="unbounded">
 								<xs:annotation>
 									<xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
 								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="feedback">
-											<xs:complexType>
-												<xs:sequence>
-													<xs:element name="answer">
-														<xs:annotation>
-															<xs:documentation>The content should be the answer given.</xs:documentation>
-														</xs:annotation>
-														<xs:complexType>
-															<xs:attribute name="question" type="xs:IDREF"/>
-														</xs:complexType>
-														<xs:keyref name="answer_question" refer="question_id">
-															<xs:selector xpath="answer"/>
-															<xs:field xpath="@question"/>
-														</xs:keyref>
-													</xs:element>
-												</xs:sequence>
-												<xs:attribute name="source-team" type="xs:IDREF" use="optional"/>
-												<xs:attribute name="source-adjudicator" type="xs:IDREF" use="optional"/>
-												<xs:attribute name="debate" type="xs:IDREF"/>
-												<xs:attribute name="score" type="xs:decimal"/>
-											</xs:complexType>
-											<xs:keyref name="feedback_source_team" refer="team_id">
-												<xs:selector xpath="feedback"/>
-												<xs:field xpath="@source-team"/>
-											</xs:keyref>
-											<xs:keyref name="feedback_source_adj" refer="adjudicator_id">
-												<xs:selector xpath="feedback"/>
-												<xs:field xpath="@source-adjudicator"/>
-											</xs:keyref>
-											<xs:keyref name="feedback_debate" refer="debate_id">
-												<xs:selector xpath="feedback"/>
-												<xs:field xpath="@debate"/>
-											</xs:keyref>
-										</xs:element>
-									</xs:sequence>
-									<xs:attribute name="gender" type="xs:string" use="optional"/>
-									<xs:attribute name="id" type="xs:ID"/>
-									<xs:attribute name="name" type="xs:string"/>
-									<xs:attribute name="core" type="xs:boolean"/>
-									<xs:attribute name="independent" type="xs:boolean"/>
-									<xs:attribute default="0.0" name="score" type="xs:float" use="optional"/>
-									<xs:attribute name="institutions" type="xs:IDREFS"/>
+								<xs:complexType mixed="true">
+									<xs:complexContent>
+										<xs:extension base="person">
+											<xs:sequence>
+												<xs:element name="feedback" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="answer" minOccurs="0" maxOccurs="unbounded">
+																<xs:annotation>
+																	<xs:documentation>The content should be the answer given.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:simpleContent>
+																		<xs:extension base="xs:string">
+																			<xs:attribute name="question" type="xs:IDREF"/>
+																		</xs:extension>
+																	</xs:simpleContent>
+																</xs:complexType>
+																<xs:keyref name="answer_question" refer="question_id">
+																	<xs:selector xpath="answer"/>
+																	<xs:field xpath="@question"/>
+																</xs:keyref>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="source-team" type="xs:IDREF" use="optional"/>
+														<xs:attribute name="source-adjudicator" type="xs:IDREF" use="optional"/>
+														<xs:attribute name="debate" type="xs:IDREF"/>
+														<xs:attribute name="score" type="xs:decimal"/>
+													</xs:complexType>
+													<xs:keyref name="feedback_source_team" refer="team_id">
+														<xs:selector xpath="feedback"/>
+														<xs:field xpath="@source-team"/>
+													</xs:keyref>
+													<xs:keyref name="feedback_source_adj" refer="adjudicator_id">
+														<xs:selector xpath="feedback"/>
+														<xs:field xpath="@source-adjudicator"/>
+													</xs:keyref>
+													<xs:keyref name="feedback_debate" refer="debate_id">
+														<xs:selector xpath="feedback"/>
+														<xs:field xpath="@debate"/>
+													</xs:keyref>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="core" type="xs:boolean"/>
+											<xs:attribute name="independent" type="xs:boolean"/>
+											<xs:attribute default="0.0" name="score" type="xs:float" use="optional"/>
+										</xs:extension>
+									</xs:complexContent>
 								</xs:complexType>
 								<xs:key name="adjudicator_id">
 									<xs:selector xpath="adjudicator"/>
@@ -240,26 +207,30 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="institution">
+				<xs:element name="institution" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution. Its name should be the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
-						<xs:attribute name="id" type="xs:ID"/>
-						<xs:attribute name="reference" type="xs:string"/>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="id" type="xs:ID"/>
+								<xs:attribute name="reference" type="xs:string"/>
+							</xs:extension>
+						</xs:simpleContent>
 					</xs:complexType>
 					<xs:key name="institution_id">
 						<xs:selector xpath="institution"/>
 						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
-				<xs:element name="motion">
+				<xs:element name="motion" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them. The resolution should be the non-element content of the tag.</xs:documentation>
 					</xs:annotation>
-					<xs:complexType>
+					<xs:complexType mixed="true">
 						<xs:sequence>
-							<xs:element name="info-slide" type="xs:string"/>
+							<xs:element name="info-slide" type="xs:string" minOccurs="0" maxOccurs="1"/>
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID" use="required"/>
 						<xs:attribute name="reference"/>
@@ -274,31 +245,35 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
-				<xs:element name="venue">
+				<xs:element name="venue" minOccurs="1" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced. Its name, excluding category suffixes, should be the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
-						<xs:attribute name="id" type="xs:ID" use="required"/>
-						<xs:attribute name="categories" use="optional">
-							<xs:annotation>
-								<xs:documentation>Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="score" type="xs:float" use="optional"/>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="id" type="xs:ID" use="required"/>
+								<xs:attribute name="categories" use="optional">
+									<xs:annotation>
+										<xs:documentation>Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="score" type="xs:float" use="optional"/>
+							</xs:extension>
+						</xs:simpleContent>
 					</xs:complexType>
 					<xs:key name="venue_id">
 						<xs:selector xpath="venue"/>
 						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
-				<xs:element name="question">
+				<xs:element name="question" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>A question posed to participant(s) of each debate on an adjudicator. The text of the question should be its content.</xs:documentation>
 					</xs:annotation>
-					<xs:complexType>
+					<xs:complexType mixed="true">
 						<xs:sequence>
-							<xs:element name="choice"/>
+							<xs:element name="choice" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID"/>
 						<xs:attribute name="name" type="xs:string"/>
@@ -315,22 +290,30 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
-				<xs:element name="break-category">
+				<xs:element name="break-category" minOccurs="0" maxOccurs="10">
 					<xs:annotation>
 						<xs:documentation>A break category. Its name should be the content.</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
-						<xs:attribute name="id" type="xs:ID"/>
-						<xs:attribute name="priority" type="xs:decimal"/>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="id" type="xs:ID"/>
+								<xs:attribute name="priority" type="xs:decimal"/>
+							</xs:extension>
+						</xs:simpleContent>
 					</xs:complexType>
 					<xs:key name="break_category_id">
 						<xs:selector xpath="break-category"/>
 						<xs:field xpath="@id"/>
 					</xs:key>
 				</xs:element>
-				<xs:element name="speaker-category">
+				<xs:element name="speaker-category" minOccurs="0" maxOccurs="unbounded">
 					<xs:complexType>
-						<xs:attribute name="id" type="xs:ID"/>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="id" type="xs:ID"/>
+							</xs:extension>
+						</xs:simpleContent>
 					</xs:complexType>
 					<xs:key name="speaker_category_id">
 						<xs:selector xpath="speaker-category"/>
@@ -347,4 +330,43 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 			<xs:attribute name="end-date" type="xs:date" use="optional"/>
 		</xs:complexType>
 	</xs:element>
+	<xs:element name="ballot">
+		<xs:annotation>
+			<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score, or whether the team advanced (true/false), should be its content. Win or lose should be determined by comparing the rank or the score of all sides of the debate. Please note that it is not the collection of scores by the same adjudicator. The score should be its content, using criteria subelements if applicable.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType mixed="true">
+			<xs:sequence>
+				<xs:element name="score" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>One of the scores given for the speech in relation to a marking rubric. The score is the content.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:attribute name="criterion" type="xs:string"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+			<xs:attribute default="false" name="minority" type="xs:boolean"/>
+			<xs:attribute name="rank" type="xs:integer" use="optional"/>
+			<xs:attribute default="false" name="ignored" type="xs:boolean" use="optional"/>
+		</xs:complexType>
+		<xs:keyref name="ballot_adjudicators" refer="adjudicator_id">
+			<xs:selector xpath="ballot"/>
+			<xs:field xpath="@adjudicators"/>
+		</xs:keyref>
+	</xs:element>
+	<xs:complexType name="person" mixed="true">
+		<xs:attribute name="id" type="xs:ID"/>
+		<xs:attribute name="gender" use="optional">
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="m"/>
+					<xs:enumeration value="f"/>
+					<xs:enumeration value="o"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="institutions" type="xs:IDREFS"/>
+		<xs:attribute name="name" type="xs:string" use="optional"/>
+	</xs:complexType>
 </xs:schema>

--- a/dta.xsd
+++ b/dta.xsd
@@ -3,18 +3,102 @@
     xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
     vc:minVersion="1.1">
     <xs:element name="tournament">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Tournaments are the core of the data collected as part of debates.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:all>
+                <xs:element name="participants">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="team">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element ref="speaker"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="name"/>
+                                    <xs:attribute name="reference"/>
+                                    <xs:attribute name="institution"/>
+                                    <xs:attribute name="code"/>
+                                </xs:complexType>
+                                <xs:key name="team_ref">
+                                    <xs:selector xpath="team"/>
+                                    <xs:field xpath="reference"/>
+                                </xs:key>
+                            </xs:element>
+                            <xs:element name="adjudicator">
+                                <xs:annotation>
+                                    <xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="feedback">
+                                            <xs:annotation>
+                                                <xs:documentation>Feedback is submitted towards adjudicators to comment on their competence in certain respects, depending on their role and who is submitting feedback. The parent element should be the adjudicator receiving the feedback.</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="source-team"/>
+                                                <xs:attribute name="source-adjudicator"/>
+                                                <xs:attribute name="score"/>
+                                            </xs:complexType>
+                                            <xs:keyref name="feedback_source-team" refer="team_ref">
+                                                <xs:selector xpath="feedback"/>
+                                                <xs:field xpath="source-team"/>
+                                            </xs:keyref>
+                                            <xs:keyref name="feedback_source-adj" refer="adj_name">
+                                                <xs:selector xpath="feedback"/>
+                                                <xs:field xpath="source-adjudicator"/>
+                                            </xs:keyref>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="institutions"/>
+                                    <xs:attribute name="current-institution"/>
+                                    <xs:attribute name="name"/>
+                                    <xs:attribute name="score" type="xs:decimal"/>
+                                    <xs:attribute name="core" type="xs:boolean"/>
+                                    <xs:attribute name="independant" type="xs:boolean"/>
+                                    <xs:attribute name="gender"/>
+                                </xs:complexType>
+                                <xs:key name="adj_name">
+                                    <xs:selector xpath="adjudicator"/>
+                                    <xs:field xpath="name"/>
+                                </xs:key>
+                                <xs:keyref name="adjudicator_current-institution"
+                                    refer="institution_ref">
+                                    <xs:selector xpath="adjudicator"/>
+                                    <xs:field xpath="current-institution"/>
+                                </xs:keyref>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="round">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
+                    </xs:annotation>
                     <xs:complexType>
                         <xs:sequence>
                             <xs:element name="debate">
+                                <xs:annotation>
+                                    <xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result.</xs:documentation>
+                                </xs:annotation>
                                 <xs:complexType>
                                     <xs:choice>
                                         <xs:element name="speech">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred.
+
+Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
+                                            </xs:annotation>
                                             <xs:complexType>
                                                 <xs:sequence>
-                                                  <xs:element name="ballot"/>
+                                                  <xs:element ref="ballot"/>
                                                 </xs:sequence>
                                                 <xs:attribute name="reply" type="xs:boolean"/>
                                                 <xs:attribute name="enhancements">
@@ -29,7 +113,7 @@
                                                 <xs:field xpath="speaker"/>
                                             </xs:keyref>
                                         </xs:element>
-                                        <xs:element name="ballot"/>
+                                        <xs:element ref="ballot"/>
                                     </xs:choice>
                                     <xs:attribute name="motion"/>
                                     <xs:attribute name="venue"/>
@@ -54,72 +138,6 @@
                         <xs:field xpath="motion"/>
                     </xs:keyref>
                 </xs:element>
-                <xs:element name="participants">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="team">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element name="speaker">
-                                            <xs:complexType>
-                                                <xs:attribute name="institutions"/>
-                                                <xs:attribute name="email"/>
-                                                <xs:attribute name="name"/>
-                                            </xs:complexType>
-                                            <xs:key name="speaker_name">
-                                                <xs:selector xpath="speaker"/>
-                                                <xs:field xpath="named"/>
-                                            </xs:key>
-                                        </xs:element>
-                                    </xs:sequence>
-                                    <xs:attribute name="name"/>
-                                    <xs:attribute name="reference" type="xs:string"/>
-                                    <xs:attribute name="institution"/>
-                                    <xs:attribute name="code"/>
-                                </xs:complexType>
-                                <xs:key name="team_ref">
-                                    <xs:selector xpath="team"/>
-                                    <xs:field xpath="reference"/>
-                                </xs:key>
-                            </xs:element>
-                            <xs:element name="adjudicator">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element name="feedback">
-                                            <xs:complexType>
-                                                <xs:attribute name="source-team"/>
-                                                <xs:attribute name="source-adjudicator"/>
-                                            </xs:complexType>
-                                            <xs:keyref name="feedback_source-team" refer="team_ref">
-                                                <xs:selector xpath="feedback"/>
-                                                <xs:field xpath="source-team"/>
-                                            </xs:keyref>
-                                            <xs:keyref name="feedback_source-adj" refer="adj_name">
-                                                <xs:selector xpath="feedback"/>
-                                                <xs:field xpath="source-adjudicator"/>
-                                            </xs:keyref>
-                                        </xs:element>
-                                    </xs:sequence>
-                                    <xs:attribute name="institutions"/>
-                                    <xs:attribute name="current-institution"/>
-                                    <xs:attribute name="name"/>
-                                    <xs:attribute name="score" type="xs:decimal"/>
-                                    <xs:attribute name="core" type="xs:boolean"/>
-                                    <xs:attribute name="independant" type="xs:boolean"/>
-                                </xs:complexType>
-                                <xs:key name="adj_name">
-                                    <xs:selector xpath="adjudicator"/>
-                                    <xs:field xpath="name"/>
-                                </xs:key>
-                                <xs:keyref name="adjudicator_current-institution"
-                                    refer="institution_ref">
-                                    <xs:selector xpath="adjudicator"/>
-                                    <xs:field xpath="current-institution"/>
-                                </xs:keyref>
-                            </xs:element>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
             </xs:all>
             <xs:attribute name="name"/>
             <xs:attribute name="format"/>
@@ -132,13 +150,24 @@
             <xs:field xpath="host"/>
         </xs:keyref>
     </xs:element>
-    <xs:element name="motion">
+    <xs:element abstract="true" name="ballot">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:element name="info-slide"/>
-                <xs:element name="resolution"/>
-            </xs:sequence>
+            <xs:attribute name="adjudicators"/>
+            <xs:attribute name="minority" type="xs:boolean"/>
+            <xs:attribute name="score"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="motion">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
             <xs:attribute name="reference"/>
+            <xs:attribute name="info-slide"/>
+            <xs:attribute name="resolution"/>
         </xs:complexType>
         <xs:key name="motion_ref">
             <xs:selector xpath="motion"/>
@@ -146,42 +175,61 @@
         </xs:key>
     </xs:element>
     <xs:element name="institution">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:attribute name="reference"/>
             <xs:attribute name="name"/>
+            <xs:attribute name="region"/>
         </xs:complexType>
         <xs:key name="institution_ref">
             <xs:selector xpath="institution"/>
             <xs:field xpath="reference"/>
         </xs:key>
     </xs:element>
-    <xs:element name="venues">
+    <xs:element name="venue">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:element name="venue-category">
-                    <xs:complexType>
-                        <xs:attribute name="reference"/>
-                    </xs:complexType>
-                    <xs:key name="venue-category_ref">
-                        <xs:selector xpath="venue-category"/>
-                        <xs:field xpath="reference"/>
-                    </xs:key>
-                </xs:element>
-                <xs:element name="venue">
-                    <xs:complexType>
-                        <xs:attribute name="reference"/>
-                        <xs:attribute name="categories" use="required"/>
-                    </xs:complexType>
-                    <xs:key name="venue_ref">
-                        <xs:selector xpath="venue"/>
-                        <xs:field xpath="reference"/>
-                    </xs:key>
-                    <xs:keyref name="venue_categories" refer="venue-category_ref">
-                        <xs:selector xpath="venue"/>
-                        <xs:field xpath="categories"/>
-                    </xs:keyref>
-                </xs:element>
-            </xs:sequence>
+            <xs:attribute name="reference"/>
+            <xs:attribute name="categories"/>
         </xs:complexType>
+        <xs:key name="venue_ref">
+            <xs:selector xpath="venue"/>
+            <xs:field xpath="reference"/>
+        </xs:key>
+        <xs:keyref name="venue_categories" refer="venue-category_ref">
+            <xs:selector xpath="venue"/>
+            <xs:field xpath="categories"/>
+        </xs:keyref>
+    </xs:element>
+    <xs:element name="venue-category">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="reference"/>
+        </xs:complexType>
+        <xs:key name="venue-category_ref">
+            <xs:selector xpath="venue-category"/>
+            <xs:field xpath="reference"/>
+        </xs:key>
+    </xs:element>
+    <xs:element name="speaker">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="institutions"/>
+            <xs:attribute name="email"/>
+            <xs:attribute name="name"/>
+            <xs:attribute name="gender"/>
+        </xs:complexType>
+        <xs:key name="speaker_name">
+            <xs:selector xpath="speaker"/>
+            <xs:field xpath="named"/>
+        </xs:key>
     </xs:element>
 </xs:schema>

--- a/dta.xsd
+++ b/dta.xsd
@@ -50,9 +50,19 @@ Duplicate speeches (iron-man) should show as a separate speech.</xs:documentatio
 															<xs:sequence>
 																<xs:element name="ballot">
 																	<xs:annotation>
-																		<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score should be its content.</xs:documentation>
+																		<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score should be its content, with criteria if applicable.</xs:documentation>
 																	</xs:annotation>
 																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="score">
+																				<xs:annotation>
+																					<xs:documentation>One of the scores given for the speech in relation to a marking rubric. The score is the content.</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:attribute name="criterion" type="xs:string"/>
+																				</xs:complexType>
+																			</xs:element>
+																		</xs:sequence>
 																		<xs:attribute name="adjudicators" type="xs:IDREFS"/>
 																		<xs:attribute name="rank" type="xs:integer" use="optional"/>
 																	</xs:complexType>

--- a/dta.xsd
+++ b/dta.xsd
@@ -1,235 +1,210 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" elementFormDefault="qualified"
-    vc:minVersion="1.1">
-    <xs:element name="tournament">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">Tournaments are the core of the data collected as part of debates.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="participants">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="team">
-                                <xs:annotation>
-                                    <xs:documentation xml:lang="en">Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element ref="speaker"/>
-                                    </xs:sequence>
-                                    <xs:attribute name="name"/>
-                                    <xs:attribute name="reference"/>
-                                    <xs:attribute name="institution"/>
-                                    <xs:attribute name="code"/>
-                                </xs:complexType>
-                                <xs:key name="team_ref">
-                                    <xs:selector xpath="team"/>
-                                    <xs:field xpath="reference"/>
-                                </xs:key>
-                            </xs:element>
-                            <xs:element name="adjudicator">
-                                <xs:annotation>
-                                    <xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element name="feedback">
-                                            <xs:annotation>
-                                                <xs:documentation>Feedback is submitted towards adjudicators to comment on their competence in certain respects, depending on their role and who is submitting feedback. The parent element should be the adjudicator receiving the feedback.</xs:documentation>
-                                            </xs:annotation>
-                                            <xs:complexType>
-                                                <xs:attribute name="source-team"/>
-                                                <xs:attribute name="source-adjudicator"/>
-                                                <xs:attribute name="score"/>
-                                            </xs:complexType>
-                                            <xs:keyref name="feedback_source-team" refer="team_ref">
-                                                <xs:selector xpath="feedback"/>
-                                                <xs:field xpath="source-team"/>
-                                            </xs:keyref>
-                                            <xs:keyref name="feedback_source-adj" refer="adj_name">
-                                                <xs:selector xpath="feedback"/>
-                                                <xs:field xpath="source-adjudicator"/>
-                                            </xs:keyref>
-                                        </xs:element>
-                                    </xs:sequence>
-                                    <xs:attribute name="institutions"/>
-                                    <xs:attribute name="current-institution"/>
-                                    <xs:attribute name="name"/>
-                                    <xs:attribute name="score" type="xs:decimal"/>
-                                    <xs:attribute name="core" type="xs:boolean"/>
-                                    <xs:attribute name="independant" type="xs:boolean"/>
-                                    <xs:attribute name="gender"/>
-                                </xs:complexType>
-                                <xs:key name="adj_name">
-                                    <xs:selector xpath="adjudicator"/>
-                                    <xs:field xpath="name"/>
-                                </xs:key>
-                                <xs:keyref name="adjudicator_current-institution"
-                                    refer="institution_ref">
-                                    <xs:selector xpath="adjudicator"/>
-                                    <xs:field xpath="current-institution"/>
-                                </xs:keyref>
-                            </xs:element>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="round">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
-                    </xs:annotation>
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="debate">
-                                <xs:annotation>
-                                    <xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result.</xs:documentation>
-                                </xs:annotation>
-                                <xs:complexType>
-                                    <xs:choice>
-                                        <xs:element name="speech">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred.
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="tournament">
+		<xs:annotation>
+			<xs:documentation>Tournaments are the core of the data collected as part of debates.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="round">
+				<xs:annotation>
+					<xs:documentation>A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="debate">
+							<xs:annotation>
+								<xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="side">
+										<xs:annotation>
+											<xs:documentation>Opposing speeches are often grouped as sides to a debate, with each team representing a position.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="ballot" type="xs:string">
+													<xs:annotation>
+														<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator.</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+														<xs:attribute default="false" name="minority" type="xs:boolean"/>
+													</xs:complexType>
+													<xs:attribute name="rank" type="xs:integer" use="optional"/>
+													<xs:keyref name="team_ballot_adjudicators" refer="adjudicator_id"/>
+												</xs:element>
+												<xs:element name="speech">
+													<xs:annotation>
+														<xs:documentation>Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred.
 
 Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
-                                            </xs:annotation>
-                                            <xs:complexType>
-                                                <xs:sequence>
-                                                  <xs:element ref="ballot"/>
-                                                </xs:sequence>
-                                                <xs:attribute name="reply" type="xs:boolean"/>
-                                                <xs:attribute name="enhancements">
-                                                  <xs:simpleType>
-                                                  <xs:list itemType="xs:string"/>
-                                                  </xs:simpleType>
-                                                </xs:attribute>
-                                                <xs:attribute name="speaker"/>
-                                            </xs:complexType>
-                                            <xs:keyref name="speech_speaker" refer="speaker_name">
-                                                <xs:selector xpath="speech"/>
-                                                <xs:field xpath="speaker"/>
-                                            </xs:keyref>
-                                        </xs:element>
-                                        <xs:element ref="ballot"/>
-                                    </xs:choice>
-                                    <xs:attribute name="motion"/>
-                                    <xs:attribute name="venue"/>
-                                </xs:complexType>
-                                <xs:keyref name="debate_motion" refer="motion_ref">
-                                    <xs:selector xpath="debate"/>
-                                    <xs:field xpath="motion"/>
-                                </xs:keyref>
-                                <xs:keyref name="debate_venue" refer="venue_ref">
-                                    <xs:selector xpath="debate"/>
-                                    <xs:field xpath="venue"/>
-                                </xs:keyref>
-                            </xs:element>
-                        </xs:sequence>
-                        <xs:attribute name="elimination" type="xs:boolean"/>
-                        <xs:attribute name="name" type="xs:string"/>
-                        <xs:attribute name="abbreviation" type="xs:string"/>
-                        <xs:attribute name="motion"/>
-                    </xs:complexType>
-                    <xs:keyref name="round_motions" refer="motion_ref">
-                        <xs:selector xpath="round"/>
-                        <xs:field xpath="motion"/>
-                    </xs:keyref>
-                </xs:element>
-            </xs:all>
-            <xs:attribute name="name"/>
-            <xs:attribute name="format"/>
-            <xs:attribute name="start-date"/>
-            <xs:attribute name="end-date"/>
-            <xs:attribute name="host"/>
-        </xs:complexType>
-        <xs:keyref name="tournament_host" refer="institution_ref">
-            <xs:selector xpath="tournament"/>
-            <xs:field xpath="host"/>
-        </xs:keyref>
-    </xs:element>
-    <xs:element abstract="true" name="ballot">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="adjudicators"/>
-            <xs:attribute name="minority" type="xs:boolean"/>
-            <xs:attribute name="score"/>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="motion">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="reference"/>
-            <xs:attribute name="info-slide"/>
-            <xs:attribute name="resolution"/>
-        </xs:complexType>
-        <xs:key name="motion_ref">
-            <xs:selector xpath="motion"/>
-            <xs:field xpath="reference"/>
-        </xs:key>
-    </xs:element>
-    <xs:element name="institution">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="reference"/>
-            <xs:attribute name="name"/>
-            <xs:attribute name="region"/>
-        </xs:complexType>
-        <xs:key name="institution_ref">
-            <xs:selector xpath="institution"/>
-            <xs:field xpath="reference"/>
-        </xs:key>
-    </xs:element>
-    <xs:element name="venue">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="reference"/>
-            <xs:attribute name="categories"/>
-        </xs:complexType>
-        <xs:key name="venue_ref">
-            <xs:selector xpath="venue"/>
-            <xs:field xpath="reference"/>
-        </xs:key>
-        <xs:keyref name="venue_categories" refer="venue-category_ref">
-            <xs:selector xpath="venue"/>
-            <xs:field xpath="categories"/>
-        </xs:keyref>
-    </xs:element>
-    <xs:element name="venue-category">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="reference"/>
-        </xs:complexType>
-        <xs:key name="venue-category_ref">
-            <xs:selector xpath="venue-category"/>
-            <xs:field xpath="reference"/>
-        </xs:key>
-    </xs:element>
-    <xs:element name="speaker">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type.</xs:documentation>
-        </xs:annotation>
-        <xs:complexType>
-            <xs:attribute name="institutions"/>
-            <xs:attribute name="email"/>
-            <xs:attribute name="name"/>
-            <xs:attribute name="gender"/>
-        </xs:complexType>
-        <xs:key name="speaker_name">
-            <xs:selector xpath="speaker"/>
-            <xs:field xpath="named"/>
-        </xs:key>
-    </xs:element>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="ballot" type="xs:decimal">
+																<xs:annotation>
+																	<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+																</xs:complexType>
+																<xs:keyref name="speech_ballot_adjudicators" refer="adjudicator_id"/>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="speaker" type="xs:IDREF"/>
+														<xs:attribute name="reply" type="xs:boolean"/>
+													</xs:complexType>
+													<xs:keyref name="speech_speaker" refer="speaker_id"/>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="team" type="xs:IDREF"/>
+										</xs:complexType>
+										<xs:keyref name="side_team" refer="team_id"/>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="id" type="xs:ID"/>
+								<xs:attribute name="chair" type="xs:IDREF" use="optional"/>
+								<xs:attribute name="venue" type="xs:IDREF" use="optional"/>
+								<xs:attribute name="motion" type="xs:IDREF"/>
+							</xs:complexType>
+							<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+							<xs:key name="debate_id"/>
+							<xs:keyref name="debate_chair_adjudicator" refer="adjudicator_id"/>
+							<xs:keyref name="debate_venue" refer="debate_venue"/>
+							<xs:keyref name="debate_motion" refer="debate_motion"/>
+							<xs:keyref name="debate_adjudicators" refer="adjudicator_id"/>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="name" type="xs:string"/>
+					<xs:attribute name="elimination" type="xs:boolean"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="participants">
+				<xs:annotation>
+					<xs:documentation>Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="team">
+							<xs:annotation>
+								<xs:documentation>Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="speaker" type="xs:string">
+										<xs:annotation>
+											<xs:documentation>Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:attribute name="id" type="xs:ID"/>
+											<xs:attribute name="institution" type="xs:IDREF"/>
+										</xs:complexType>
+										<xs:key name="speaker_id"/>
+										<xs:keyref name="speaker_institution" refer="institution_id"/>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="id" type="xs:ID"/>
+								<xs:attribute name="code" type="xs:string"/>
+								<xs:attribute name="short" type="xs:string"/>
+								<xs:attribute name="name" type="xs:string"/>
+							</xs:complexType>
+							<xs:key name="team_id"/>
+						</xs:element>
+						<xs:element name="adjudicator" type="xs:string">
+							<xs:annotation>
+								<xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="feedback">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="answer" type="xs:string">
+													<xs:complexType>
+														<xs:attribute name="question" type="xs:IDREF"/>
+													</xs:complexType>
+													<xs:keyref name="answer_question" refer="question_id"/>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="source-team" type="xs:IDREF" use="optional"/>
+											<xs:attribute name="source-adjudicator" type="xs:IDREF" use="optional"/>
+											<xs:attribute name="debate" type="xs:IDREF"/>
+											<xs:attribute name="score" type="xs:decimal"/>
+										</xs:complexType>
+										<xs:keyref name="feedback_source_team" refer="team_id"/>
+										<xs:keyref name="feedback_source_adj" refer="adjudicator_id"/>
+										<xs:keyref name="feedback_debate" refer="debate_id"/>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+							<xs:attribute name="id" type="xs:ID"/>
+							<xs:attribute name="name" type="xs:string"/>
+							<xs:attribute name="core" type="xs:boolean"/>
+							<xs:attribute name="independent" type="xs:boolean"/>
+							<xs:key name="adjudicator_ref"/>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="institution" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="id" type="xs:ID"/>
+					<xs:attribute name="reference" type="xs:string"/>
+				</xs:complexType>
+				<xs:key name="institution_id"/>
+			</xs:element>
+			<xs:element name="motion" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="info-slide" type="xs:string"/>
+					</xs:sequence>
+					<xs:attribute name="id" type="xs:ID" use="required"/>
+					<xs:attribute name="reference"/>
+				</xs:complexType>
+				<xs:key name="motion_id"/>
+			</xs:element>
+			<xs:element name="venue" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="id" type="xs:ID" use="required"/>
+					<xs:attribute name="categories" use="optional">
+						<xs:annotation>
+							<xs:documentation>Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:key name="venue_id"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="question" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>A question posed to participant(s) of each debate on an adjudicator.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="id" type="xs:ID"/>
+					<xs:attribute name="name" type="xs:string"/>
+					<xs:attribute name="type" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>Type can be one of the following: bc for checkbox, bs for yes/no (dropdown), i for integer (textbox), is for integer scale, f for float, t for text, tl for long text, ss for select one, ms for select multiple</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="from-teams" type="xs:boolean"/>
+					<xs:attribute name="from-adjudicators" type="xs:boolean"/>
+				</xs:complexType>
+				<xs:key name="question_id"/>
+			</xs:element>
+		</xs:sequence>
+		<xs:complexType>
+			<xs:attribute name="name" type="xs:string"/>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/dta.xsd
+++ b/dta.xsd
@@ -5,206 +5,338 @@
 		<xs:annotation>
 			<xs:documentation>Tournaments are the core of the data collected as part of debates.</xs:documentation>
 		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="round">
-				<xs:annotation>
-					<xs:documentation>A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="debate">
-							<xs:annotation>
-								<xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result.</xs:documentation>
-							</xs:annotation>
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="side">
-										<xs:annotation>
-											<xs:documentation>Opposing speeches are often grouped as sides to a debate, with each team representing a position.</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="ballot" type="xs:string">
-													<xs:annotation>
-														<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator.</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:attribute name="adjudicators" type="xs:IDREFS"/>
-														<xs:attribute default="false" name="minority" type="xs:boolean"/>
-													</xs:complexType>
-													<xs:attribute name="rank" type="xs:integer" use="optional"/>
-													<xs:keyref name="team_ballot_adjudicators" refer="adjudicator_id"/>
-												</xs:element>
-												<xs:element name="speech">
-													<xs:annotation>
-														<xs:documentation>Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred.
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="round">
+					<xs:annotation>
+						<xs:documentation>A round is a collection of debates, which may have similarities in time or stage in the tournament.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="debate">
+								<xs:annotation>
+									<xs:documentation>Debates are collections of speeches between competitors which are compared to form a score/result. Byes are represented by having only one side to a debate.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="side">
+											<xs:annotation>
+												<xs:documentation>Opposing speeches are often grouped as sides to a debate, with each team representing a position.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="ballot">
+														<xs:annotation>
+															<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score, or whether the team advanced (true/false), should be its content. Win or lose should be determined by comparing the rank or the score of all sides of the debate.</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+															<xs:attribute default="false" name="minority" type="xs:boolean"/>
+															<xs:attribute name="rank" type="xs:integer" use="optional"/>
+															<xs:attribute default="false" name="ignored" type="xs:boolean" use="optional"/>
+														</xs:complexType>
+														<xs:keyref name="team_ballot_adjudicators" refer="adjudicator_id">
+															<xs:selector xpath="side/ballot"/>
+															<xs:field xpath="@adjudicators"/>
+														</xs:keyref>
+													</xs:element>
+													<xs:element name="speech">
+														<xs:annotation>
+															<xs:documentation>Each debate is comprised of speeches by members of each opposing team. These speeches may be scores individually or grouped by team. As each speech has a speaker, the team (if any) can be inferred.
 
 Duplicate speeches (iron-man) should show as a separate speech.</xs:documentation>
-													</xs:annotation>
-													<xs:complexType>
-														<xs:sequence>
-															<xs:element name="ballot" type="xs:decimal">
-																<xs:annotation>
-																	<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator.</xs:documentation>
-																</xs:annotation>
-																<xs:complexType>
-																	<xs:attribute name="adjudicators" type="xs:IDREFS"/>
-																</xs:complexType>
-																<xs:keyref name="speech_ballot_adjudicators" refer="adjudicator_id"/>
-															</xs:element>
-														</xs:sequence>
-														<xs:attribute name="speaker" type="xs:IDREF"/>
-														<xs:attribute name="reply" type="xs:boolean"/>
-													</xs:complexType>
-													<xs:keyref name="speech_speaker" refer="speaker_id"/>
-												</xs:element>
-											</xs:sequence>
-											<xs:attribute name="team" type="xs:IDREF"/>
-										</xs:complexType>
-										<xs:keyref name="side_team" refer="team_id"/>
-									</xs:element>
-								</xs:sequence>
-								<xs:attribute name="id" type="xs:ID"/>
-								<xs:attribute name="chair" type="xs:IDREF" use="optional"/>
-								<xs:attribute name="venue" type="xs:IDREF" use="optional"/>
-								<xs:attribute name="motion" type="xs:IDREF"/>
-							</xs:complexType>
-							<xs:attribute name="adjudicators" type="xs:IDREFS"/>
-							<xs:key name="debate_id"/>
-							<xs:keyref name="debate_chair_adjudicator" refer="adjudicator_id"/>
-							<xs:keyref name="debate_venue" refer="debate_venue"/>
-							<xs:keyref name="debate_motion" refer="debate_motion"/>
-							<xs:keyref name="debate_adjudicators" refer="adjudicator_id"/>
-						</xs:element>
-					</xs:sequence>
-					<xs:attribute name="name" type="xs:string"/>
-					<xs:attribute name="elimination" type="xs:boolean"/>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="participants">
-				<xs:annotation>
-					<xs:documentation>Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="team">
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="ballot">
+																	<xs:annotation>
+																		<xs:documentation>A ballot is an atomic score/result given by adjudicators towards a team or speaker and not the collection of scores by the same adjudicator. The score should be its content.</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+																		<xs:attribute name="rank" type="xs:integer" use="optional"/>
+																	</xs:complexType>
+																	<xs:keyref name="speech_ballot_adjudicators" refer="adjudicator_id">
+																		<xs:selector xpath="speech/ballot"/>
+																		<xs:field xpath="@adjudicators"/>
+																	</xs:keyref>
+																</xs:element>
+															</xs:sequence>
+															<xs:attribute name="speaker" type="xs:IDREF"/>
+															<xs:attribute name="reply" type="xs:boolean"/>
+														</xs:complexType>
+														<xs:keyref name="speech_speaker" refer="speaker_id">
+															<xs:selector xpath="speech"/>
+															<xs:field xpath="@speaker"/>
+														</xs:keyref>
+													</xs:element>
+												</xs:sequence>
+												<xs:attribute name="team" type="xs:IDREF"/>
+												<xs:attribute name="forfeit" type="xs:boolean" use="optional" default="false"/>
+											</xs:complexType>
+											<xs:keyref name="side_team" refer="team_id">
+												<xs:selector xpath="side"/>
+												<xs:field xpath="@team"/>
+											</xs:keyref>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="id" type="xs:ID"/>
+									<xs:attribute name="chair" type="xs:IDREF" use="optional"/>
+									<xs:attribute name="venue" type="xs:IDREF" use="optional"/>
+									<xs:attribute name="motion" type="xs:IDREF"/>
+									<xs:attribute name="adjudicators" type="xs:IDREFS"/>
+								</xs:complexType>
+								<xs:key name="debate_id">
+									<xs:selector xpath="debate"/>
+									<xs:field xpath="@id"/>
+								</xs:key>
+								<xs:keyref name="debate_chair_adjudicator" refer="adjudicator_id">
+									<xs:selector xpath="debate"/>
+									<xs:field xpath="@chair"/>
+								</xs:keyref>
+								<xs:keyref name="debate_venue" refer="venue_id">
+									<xs:selector xpath="debate"/>
+									<xs:field xpath="@venue"/>
+								</xs:keyref>
+								<xs:keyref name="debate_motion" refer="motion_id">
+									<xs:selector xpath="debate"/>
+									<xs:field xpath="@motion"/>
+								</xs:keyref>
+								<xs:keyref name="debate_adjudicators" refer="adjudicator_id">
+									<xs:selector xpath="debate"/>
+									<xs:field xpath="@adjudicators"/>
+								</xs:keyref>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="name" type="xs:string"/>
+						<xs:attribute default="false" name="elimination" type="xs:boolean"/>
+						<xs:attribute name="feedback-weight" type="xs:float" use="optional"/>
+						<xs:attribute name="break-category" type="xs:IDREF" use="optional"/>
+						<xs:attribute name="start" type="xs:time" use="optional"/>
+					</xs:complexType>
+					<xs:keyref name="round_break_category" refer="break_category_id">
+						<xs:selector xpath="round"/>
+						<xs:field xpath="@break-category"/>
+					</xs:keyref>
+				</xs:element>
+				<xs:element name="participants">
+					<xs:annotation>
+						<xs:documentation>Container element for competitive participants for clarity of the contents of the parent element.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="team">
+								<xs:annotation>
+									<xs:documentation>Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="speaker">
+											<xs:annotation>
+												<xs:documentation>Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type. Their name should be the content of the element.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:attribute name="id" type="xs:ID"/>
+												<xs:attribute name="gender" type="xs:string" use="optional"/>
+												<xs:attribute name="institutions" type="xs:IDREFS"/>
+												<xs:attribute name="categories" type="xs:IDREFS"/>
+											</xs:complexType>
+											<xs:key name="speaker_id">
+												<xs:selector xpath="speaker"/>
+												<xs:field xpath="@id"/>
+											</xs:key>
+											<xs:keyref name="speaker_institution" refer="institution_id">
+												<xs:selector xpath="speaker"/>
+												<xs:field xpath="@institution"/>
+											</xs:keyref>
+											<xs:keyref name="speaker_categories" refer="speaker_category_id">
+												<xs:selector xpath="speaker"/>
+												<xs:field xpath="@categories"/>
+											</xs:keyref>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="id" type="xs:ID"/>
+									<xs:attribute name="code" type="xs:string"/>
+									<xs:attribute name="name" type="xs:string"/>
+									<xs:attribute name="break-eligibilities" type="xs:IDREFS"/>
+								</xs:complexType>
+								<xs:key name="team_id">
+									<xs:selector xpath="team"/>
+									<xs:field xpath="@id"/>
+								</xs:key>
+								<xs:keyref name="team_break_categories" refer="break_category_id">
+									<xs:selector xpath="team"/>
+									<xs:field xpath="@break-eligibilities"/>
+								</xs:keyref>
+							</xs:element>
+							<xs:element name="adjudicator">
+								<xs:annotation>
+									<xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="feedback">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="answer">
+														<xs:annotation>
+															<xs:documentation>The content should be the answer given.</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:attribute name="question" type="xs:IDREF"/>
+														</xs:complexType>
+														<xs:keyref name="answer_question" refer="question_id">
+															<xs:selector xpath="answer"/>
+															<xs:field xpath="@question"/>
+														</xs:keyref>
+													</xs:element>
+												</xs:sequence>
+												<xs:attribute name="source-team" type="xs:IDREF" use="optional"/>
+												<xs:attribute name="source-adjudicator" type="xs:IDREF" use="optional"/>
+												<xs:attribute name="debate" type="xs:IDREF"/>
+												<xs:attribute name="score" type="xs:decimal"/>
+											</xs:complexType>
+											<xs:keyref name="feedback_source_team" refer="team_id">
+												<xs:selector xpath="feedback"/>
+												<xs:field xpath="@source-team"/>
+											</xs:keyref>
+											<xs:keyref name="feedback_source_adj" refer="adjudicator_id">
+												<xs:selector xpath="feedback"/>
+												<xs:field xpath="@source-adjudicator"/>
+											</xs:keyref>
+											<xs:keyref name="feedback_debate" refer="debate_id">
+												<xs:selector xpath="feedback"/>
+												<xs:field xpath="@debate"/>
+											</xs:keyref>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="gender" type="xs:string" use="optional"/>
+									<xs:attribute name="id" type="xs:ID"/>
+									<xs:attribute name="name" type="xs:string"/>
+									<xs:attribute name="core" type="xs:boolean"/>
+									<xs:attribute name="independent" type="xs:boolean"/>
+									<xs:attribute default="0.0" name="score" type="xs:float" use="optional"/>
+									<xs:attribute name="institutions" type="xs:IDREFS"/>
+								</xs:complexType>
+								<xs:key name="adjudicator_id">
+									<xs:selector xpath="adjudicator"/>
+									<xs:field xpath="@id"/>
+								</xs:key>
+								<xs:keyref name="adjudicator_institutions" refer="institution_id">
+									<xs:selector xpath="adjudicator"/>
+									<xs:field xpath="@institutions"/>
+								</xs:keyref>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="institution">
+					<xs:annotation>
+						<xs:documentation>Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution. Its name should be the content.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:attribute name="id" type="xs:ID"/>
+						<xs:attribute name="reference" type="xs:string"/>
+					</xs:complexType>
+					<xs:key name="institution_id">
+						<xs:selector xpath="institution"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="motion">
+					<xs:annotation>
+						<xs:documentation>Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them. The resolution should be the non-element content of the tag.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="info-slide" type="xs:string"/>
+						</xs:sequence>
+						<xs:attribute name="id" type="xs:ID" use="required"/>
+						<xs:attribute name="reference"/>
+						<xs:attribute name="language" type="xs:string" use="optional">
 							<xs:annotation>
-								<xs:documentation>Teams are groups of speakers normally associated with a specific institution. In addition to ranking team members, teams are also ranked, which may determine eligibility in elimination rounds.</xs:documentation>
+								<xs:documentation>The language(s) of the motion/the debates using the motion. Use ISO 639 codes, separated by whitespace.</xs:documentation>
 							</xs:annotation>
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="speaker" type="xs:string">
-										<xs:annotation>
-											<xs:documentation>Speakers are represented without anything tournament-specific, but are most-often grouped as teams. If teams are non-existant, they may be declared outside the tournament-type.</xs:documentation>
-										</xs:annotation>
-										<xs:complexType>
-											<xs:attribute name="id" type="xs:ID"/>
-											<xs:attribute name="institution" type="xs:IDREF"/>
-										</xs:complexType>
-										<xs:key name="speaker_id"/>
-										<xs:keyref name="speaker_institution" refer="institution_id"/>
-									</xs:element>
-								</xs:sequence>
-								<xs:attribute name="id" type="xs:ID"/>
-								<xs:attribute name="code" type="xs:string"/>
-								<xs:attribute name="short" type="xs:string"/>
-								<xs:attribute name="name" type="xs:string"/>
-							</xs:complexType>
-							<xs:key name="team_id"/>
-						</xs:element>
-						<xs:element name="adjudicator" type="xs:string">
+						</xs:attribute>
+					</xs:complexType>
+					<xs:key name="motion_id">
+						<xs:selector xpath="motion"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="venue">
+					<xs:annotation>
+						<xs:documentation>Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced. Its name, excluding category suffixes, should be the content.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:attribute name="id" type="xs:ID" use="required"/>
+						<xs:attribute name="categories" use="optional">
 							<xs:annotation>
-								<xs:documentation>While an adjudicator can participate in many tournaments, their status (as indpendent, core, etc.) can vary, and so they must stay attached.</xs:documentation>
+								<xs:documentation>Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
 							</xs:annotation>
-							<xs:complexType>
-								<xs:sequence>
-									<xs:element name="feedback">
-										<xs:complexType>
-											<xs:sequence>
-												<xs:element name="answer" type="xs:string">
-													<xs:complexType>
-														<xs:attribute name="question" type="xs:IDREF"/>
-													</xs:complexType>
-													<xs:keyref name="answer_question" refer="question_id"/>
-												</xs:element>
-											</xs:sequence>
-											<xs:attribute name="source-team" type="xs:IDREF" use="optional"/>
-											<xs:attribute name="source-adjudicator" type="xs:IDREF" use="optional"/>
-											<xs:attribute name="debate" type="xs:IDREF"/>
-											<xs:attribute name="score" type="xs:decimal"/>
-										</xs:complexType>
-										<xs:keyref name="feedback_source_team" refer="team_id"/>
-										<xs:keyref name="feedback_source_adj" refer="adjudicator_id"/>
-										<xs:keyref name="feedback_debate" refer="debate_id"/>
-									</xs:element>
-								</xs:sequence>
-							</xs:complexType>
-							<xs:attribute name="id" type="xs:ID"/>
-							<xs:attribute name="name" type="xs:string"/>
-							<xs:attribute name="core" type="xs:boolean"/>
-							<xs:attribute name="independent" type="xs:boolean"/>
-							<xs:key name="adjudicator_ref"/>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="institution" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Institutions represent collections of individuals with a shared debating history. This means that members are more familiar with each-other and so judging within is to be avoided. All participants may have affiliations, and teams may be categorized by their institution.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute name="id" type="xs:ID"/>
-					<xs:attribute name="reference" type="xs:string"/>
-				</xs:complexType>
-				<xs:key name="institution_id"/>
-			</xs:element>
-			<xs:element name="motion" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Motions are not exclusive to a tournament, and so have been set apart. Rounds and debates may reference them.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="info-slide" type="xs:string"/>
-					</xs:sequence>
-					<xs:attribute name="id" type="xs:ID" use="required"/>
-					<xs:attribute name="reference"/>
-				</xs:complexType>
-				<xs:key name="motion_id"/>
-			</xs:element>
-			<xs:element name="venue" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Venues are where debates may take place. Specific attributes that a venue has should be added as a venue-category and referenced.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute name="id" type="xs:ID" use="required"/>
-					<xs:attribute name="categories" use="optional">
-						<xs:annotation>
-							<xs:documentation>Venue categories are a simple reference element to designate venues with a similarity, such as being easily accessible.</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:key name="venue_id"/>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="question" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>A question posed to participant(s) of each debate on an adjudicator.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute name="id" type="xs:ID"/>
-					<xs:attribute name="name" type="xs:string"/>
-					<xs:attribute name="type" type="xs:string">
-						<xs:annotation>
-							<xs:documentation>Type can be one of the following: bc for checkbox, bs for yes/no (dropdown), i for integer (textbox), is for integer scale, f for float, t for text, tl for long text, ss for select one, ms for select multiple</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="from-teams" type="xs:boolean"/>
-					<xs:attribute name="from-adjudicators" type="xs:boolean"/>
-				</xs:complexType>
-				<xs:key name="question_id"/>
-			</xs:element>
-		</xs:sequence>
-		<xs:complexType>
+						</xs:attribute>
+						<xs:attribute name="score" type="xs:float" use="optional"/>
+					</xs:complexType>
+					<xs:key name="venue_id">
+						<xs:selector xpath="venue"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="question">
+					<xs:annotation>
+						<xs:documentation>A question posed to participant(s) of each debate on an adjudicator. The text of the question should be its content.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:attribute name="id" type="xs:ID"/>
+						<xs:attribute name="name" type="xs:string"/>
+						<xs:attribute name="type" type="xs:string">
+							<xs:annotation>
+								<xs:documentation>Type can be one of the following: bc for checkbox, bs for yes/no (dropdown), i for integer (textbox), is for integer scale, f for float, t for text, tl for long text, ss for select one, ms for select multiple</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="from-teams" type="xs:boolean"/>
+						<xs:attribute name="from-adjudicators" type="xs:boolean"/>
+						<xs:attribute name="choices" type="xs:string" use="optional">
+							<xs:annotation>
+								<xs:documentation>Separate using pipes (&quot;|&quot;). Only use if type is of a choice.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+					<xs:key name="question_id">
+						<xs:selector xpath="question"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="break-category">
+					<xs:annotation>
+						<xs:documentation>A break category. Its name should be the content.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:attribute name="id" type="xs:ID"/>
+						<xs:attribute name="priority" type="xs:decimal"/>
+					</xs:complexType>
+					<xs:key name="break_category_id">
+						<xs:selector xpath="break-category"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
+				<xs:element name="speaker-category">
+					<xs:complexType>
+						<xs:attribute name="id" type="xs:ID"/>
+					</xs:complexType>
+					<xs:key name="speaker_category_id">
+						<xs:selector xpath="speaker-category"/>
+						<xs:field xpath="@id"/>
+					</xs:key>
+				</xs:element>
+			</xs:sequence>
 			<xs:attribute name="name" type="xs:string"/>
+			<xs:attribute name="short" type="xs:string" use="optional"/>
+			<xs:attribute name="host" type="xs:string" use="optional"/>
+			<xs:attribute name="style" type="xs:string" use="optional"/>
+			<xs:attribute name="language" type="xs:string" use="optional"/>
+			<xs:attribute name="start-date" type="xs:date" use="optional"/>
+			<xs:attribute name="end-date" type="xs:date" use="optional"/>
 		</xs:complexType>
 	</xs:element>
 </xs:schema>


### PR DESCRIPTION
This commit starts the development of this XML schema standard with a basic hierarchical structure of debates inside a tournament.

Inside the schema, the basic structure goes:

- Tournament
  - Round
    - Debate
      - Speech
        - (Ballot)
      - (Ballot)
  - Participants
    - Team
      - Speaker
    - Adjudicator
- Motion
  - Info-slide
  - Resolution
- Venues
  - Venue-category
  - Venue

Attributes of each element are not completed in this patch, nor possibly the elements. Here is an automatic diagram:

Link to: [debate_schema](https://user-images.githubusercontent.com/6293465/50625165-9c662c80-0efc-11e9-9b64-1063b7f6c47b.png)

Some design notes. XML is very flexible and there are many ways to model the same thing. Here, I have put a preference of using attributes and preferring only having other tags as the content of the ancestor element.

* The info-slide element of `Motion` might as well be an attribute with the text as the content
* Whether "container" elements should be used (`Venues`, `Participants`)
* Ballots are found both by-speaker and by-debate to accommodate speaker scores (or the lack thereof)
* `Speaker` should be like `Ballot` for team-less tournaments by having an abstract element used in various hierarchies.

Thoughts on the rough sketch? As a comparison with #1, there is minimal consideration of formats, of which should be expanded. Further, attributes are preferred over elements here. Rounds are subdivided into debates and speeches (ballot element must be worked on). Cross-referencing is done with reference attributes and constraints.