### PR TITLE
Clarify motion selection in CP

### DIFF
--- a/styles.md
+++ b/styles.md
@@ -12,7 +12,7 @@ NZ Easters | 2 teams of 2 + replies | speaks only, integers (½ for replies), st
 NZ Joynt | 2 teams of 3 + replies | speaks only, integers (½ for replies), strict order | voting, one per judge, average over majority | one per round
 Asians | 2 teams of 3 + replies | _??_ | _??_ | _??_ 
 APDA (US) | 2 teams of 2 + replies | speaks and ranks, integers (no reply score), tied-speaks tied-rank wins allowed | varies from tournament to tournament | no motions at most tournaments (governments run cases), a few per year have motions
-CP (Canada) | 2 teams of 2 + replies, can merge opp 2nd/reply | speaks only, integers (no reply score), strict order | consensus, one per debate | no motions (governments run cases)
+CP (Canada) | 2 teams of 2 + replies, can merge opp 2nd/reply | speaks only, integers (no reply score), strict order | consensus, one per debate | no motions for English (governments run cases), but may be provided. French have one per debate
 OPD (Germany) | 2 teams of 3 + 3 unaligned speakers | _??_ | _??_ | _??_
 NPDA (US) |  _??_ | _??_ | _??_  | _??_
 [Paris V](http://www.frenchdebatingassociation.fr/debating-rules/) | 2 teams of 5 | none? | voting, one per judge | one per debate


### PR DESCRIPTION
CP, the initialism for the Canadian Parliamentary debate style, has an odd motion selection system. Some tournaments provide a "straight" motion that the government may choose to run instead of their case.

Other tournaments impose motions (one by round). French CP, in particular, imposes motions.